### PR TITLE
Implemented func.: view an item & modified layout

### DIFF
--- a/MyInventoryApp/app/src/main/java/com/example/myinventoryapp/EditActivity.java
+++ b/MyInventoryApp/app/src/main/java/com/example/myinventoryapp/EditActivity.java
@@ -1,0 +1,14 @@
+package com.example.myinventoryapp;
+
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class EditActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_edit);
+
+    }
+}

--- a/MyInventoryApp/app/src/main/java/com/example/myinventoryapp/ViewItemActivity.java
+++ b/MyInventoryApp/app/src/main/java/com/example/myinventoryapp/ViewItemActivity.java
@@ -1,0 +1,81 @@
+package com.example.myinventoryapp;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.firebase.firestore.DocumentReference;
+
+import java.util.Map;
+
+public class ViewItemActivity extends AppCompatActivity {
+    EditText serialField;
+    EditText dateField;
+    EditText makeField;
+    EditText priceField;
+    EditText descField;
+    EditText modelField;
+    DocumentReference fb_view_item;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_review);
+
+        // get name of the item that was clicked to get user's path make and model:
+        Intent intent = getIntent();
+        String itemName = intent.getStringExtra("item_name");
+        // split the item name into "make" and "model" using a space as the delimiter
+        String[] parts = itemName.split(" ");
+        // access "make" and "model" from the parts array
+        String make = parts[0];
+        String model = parts[1];
+
+        // find the IDs of all the list of information when viewing an item, but get it from firebase
+        serialField = findViewById(R.id.serialNumEdit);
+        dateField = findViewById(R.id.acqDateEdit);
+        makeField = findViewById(R.id.makeEdit);
+        priceField = findViewById(R.id.estPriceEdit);
+        descField = findViewById(R.id.descEdit);
+        modelField = findViewById(R.id.modelEdit);
+
+        // access the database of default user make and model
+        fb_view_item = ((Global) getApplication()).DocumentRef(make, model);
+
+        // get keys and set values to appropriate text fields
+        fb_view_item.get().addOnSuccessListener(documentSnapshot -> {
+            Map<String, Object> data = documentSnapshot.getData();
+            serialField.setText((String) data.get("serial"));
+            dateField.setText((String) data.get("date"));
+            makeField.setText((String) data.get("make"));
+            priceField.setText((String) data.get("price"));
+            descField.setText((String) data.get("desc"));
+            modelField.setText((String) data.get("model"));
+        });
+
+        // Back Button
+        final Button backButton = findViewById(R.id.backButton);
+        backButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                finish();
+            }
+        });
+
+        // Edit Button
+        final Button editButton = findViewById(R.id.saveButton2);
+        editButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent2 = new Intent(ViewItemActivity.this, EditActivity.class);
+                startActivity(intent2);
+            }
+        });
+
+    }
+
+
+}

--- a/MyInventoryApp/app/src/main/res/layout/activity_review.xml
+++ b/MyInventoryApp/app/src/main/res/layout/activity_review.xml
@@ -21,15 +21,16 @@
         android:id="@+id/serialNumEdit"
         android:layout_width="wrap_content"
         android:layout_height="50dp"
-        android:layout_marginTop="30dp"
+        android:layout_marginLeft="107dp"
+        android:layout_marginTop="15dp"
         android:ems="10"
         android:hint="Serial Number"
-        android:inputType="text"
+        android:inputType="none"
+        android:enabled="false"
+        app:layout_constraintBottom_toTopOf="@id/acqDateEdit"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/logo"
-        app:layout_constraintBottom_toTopOf="@id/acqDateEdit"
-        android:layout_marginLeft="107dp"/>
+        app:layout_constraintTop_toBottomOf="@+id/logo" />
 
     <EditText
         android:id="@+id/acqDateEdit"
@@ -37,7 +38,8 @@
         android:layout_height="50dp"
         android:ems="10"
         android:hint="Acquired Date"
-        android:inputType="text"
+        android:inputType="none"
+        android:enabled="false"
         app:layout_constraintBottom_toTopOf="@+id/makeEdit"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -52,7 +54,8 @@
         android:layout_height="50dp"
         android:ems="10"
         android:hint="Make"
-        android:inputType="text"
+        android:inputType="none"
+        android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@id/estPriceEdit"
@@ -61,12 +64,27 @@
         android:layout_marginLeft="107dp"/>
 
     <EditText
+        android:id="@+id/modelEdit"
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:ems="10"
+        android:hint="Model"
+        android:inputType="none"
+        android:enabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/makeEdit"
+        app:layout_constraintBottom_toTopOf="@id/estPriceEdit"
+        android:layout_marginLeft="107dp"/>
+
+    <EditText
         android:id="@+id/estPriceEdit"
         android:layout_width="wrap_content"
         android:layout_height="50dp"
         android:ems="10"
         android:hint="Estimated Price"
-        android:inputType="text"
+        android:inputType="none"
+        android:enabled="false"
         app:layout_constraintBottom_toTopOf="@+id/descEdit"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.497"
@@ -83,7 +101,8 @@
         android:ems="10"
         android:gravity="start|top"
         android:hint="Description"
-        android:inputType="textMultiLine"
+        android:inputType="none"
+        android:enabled="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.502"
         app:layout_constraintStart_toStartOf="parent"
@@ -94,7 +113,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="20dp">
+        android:layout_marginTop="10dp">
         <HorizontalScrollView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content">
@@ -148,7 +167,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="70dp">
+        android:layout_marginTop="30dp">
 
 
         <ImageView


### PR DESCRIPTION
-   Added the ViewItemActivity class to view an item.
    It should take the item name (make and model) and find it in the
    fbdatabase and find the key values of it and set those into the text
    fields

-   Did the back button and edit button which should direct you to the
    edit activity layout which is associated with the EditActivity class
    I didn't touch on the add tags and photograph buttons

-   Added a Model EditText in the activity_review layout because it
    didn't have one and adjusted the margins to fit it all in.